### PR TITLE
Touch events modified

### DIFF
--- a/web/dict.js
+++ b/web/dict.js
@@ -284,4 +284,10 @@ $(document).ready(function() {
 		removeSelection(); // Selection text remains. So to prevent again showing pop up
 		lastMove = event;
 	});
+
+	// Apparently touchcancel is fired in android kitkat+ instead of touchend
+	$('#viewer').on('touchcancel',function(e){
+		var event = lastMove.originalEvent;
+		showPopUp(event.touches[0]);
+	});
 });


### PR DESCRIPTION
This issue occurs in Android version 4.4+. The touch events fires correctly in Android 4.2.2. Made changes as suggested here:

http://stackoverflow.com/questions/19088117/touchend-not-firing-after-touchmove